### PR TITLE
Make App::Daemon check process names, fix taint error when reading the pidfile

### DIFF
--- a/Daemon.pm
+++ b/Daemon.pm
@@ -453,7 +453,8 @@ sub pid_file_read {
     my $pid = <FILE>;
     chomp $pid if defined $pid;
     close FILE;
-    return $pid;
+    $pid =~ /^(\d+)$/; # Untaint
+    return $1;
 }
 
 ###########################################


### PR DESCRIPTION
Makes App::Daemon check whether the name of the process in the pid file is the same as its own. This helps it deal with leftover pid files that now refer to another process.

Also fixes a taint error when reading the pidfile under -T
